### PR TITLE
Remove that trailing <li>!

### DIFF
--- a/credits.html
+++ b/credits.html
@@ -83,7 +83,6 @@
             <div class="card-body">
               <h2 class="card-title">Special Thanks to:</h2>
               <li class="text-lg">BBCIA (alex) - he motivates me to do choices</li>
-              <li class="text-lg"></li>
             </div>
           </div>
 


### PR DESCRIPTION
I got a bit angry about that trailing dot in the credits menu. (:
<img width="1458" alt="image" src="https://github.com/ScottN13/ScottN13.github.io/assets/96308166/7d496541-3f87-4462-9dad-8efbe06863b0">
